### PR TITLE
Isolate collector tests from host proxy env vars and add coverage for untested component functions

### DIFF
--- a/internal/components/generic_parser_test.go
+++ b/internal/components/generic_parser_test.go
@@ -623,3 +623,83 @@ func TestGenericParser_GetDefaultConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestGenericParser_GetEnvironmentVariables(t *testing.T) {
+	type args struct {
+		logger logr.Logger
+		config any
+	}
+	type testCase[T any] struct {
+		name    string
+		g       *components.GenericParser[T]
+		args    args
+		want    []corev1.EnvVar
+		wantErr assert.ErrorAssertionFunc
+	}
+
+	envVarGenFunc := func(_ logr.Logger, config *components.SingleEndpointConfig) ([]corev1.EnvVar, error) {
+		if config.Endpoint == "" && config.ListenAddress == "" {
+			return nil, errors.New("either endpoint or listen_address must be specified")
+		}
+		return []corev1.EnvVar{
+			{Name: "TEST_VAR", Value: "test_value"},
+		}, nil
+	}
+
+	tests := []testCase[*components.SingleEndpointConfig]{
+		{
+			name: "with env var generator and valid config",
+			g:    components.NewSinglePortParserBuilder("test", 0).WithEnvVarGen(envVarGenFunc).MustBuild(),
+			args: args{
+				logger: logr.Discard(),
+				config: map[string]any{
+					"endpoint": "http://localhost:8080",
+				},
+			},
+			want: []corev1.EnvVar{
+				{Name: "TEST_VAR", Value: "test_value"},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "with env var generator and invalid config",
+			g:    components.NewSinglePortParserBuilder("test", 0).WithEnvVarGen(envVarGenFunc).MustBuild(),
+			args: args{
+				logger: logr.Discard(),
+				config: map[string]any{},
+			},
+			want:    nil,
+			wantErr: assert.Error,
+		},
+		{
+			name: "without env var generator returns nil",
+			g:    components.NewSinglePortParserBuilder("test", 0).MustBuild(),
+			args: args{
+				logger: logr.Discard(),
+				config: map[string]any{},
+			},
+			want:    nil,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "failed to parse config",
+			g:    components.NewSinglePortParserBuilder("test", 0).WithEnvVarGen(envVarGenFunc).MustBuild(),
+			args: args{
+				logger: logr.Discard(),
+				config: func() {},
+			},
+			want:    nil,
+			wantErr: assert.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.g.GetEnvironmentVariables(tt.args.logger, tt.args.config)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetEnvironmentVariables(%v, %v)", tt.args.logger, tt.args.config)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetEnvironmentVariables(%v, %v)", tt.args.logger, tt.args.config)
+		})
+	}
+}

--- a/internal/components/multi_endpoint_test.go
+++ b/internal/components/multi_endpoint_test.go
@@ -356,6 +356,9 @@ func TestMultiPortReceiver_Ports(t *testing.T) {
 			startupProbe, startupErr := s.GetStartupProbe(logr.Discard(), tt.args.config)
 			assert.NoError(t, startupErr)
 			assert.Nil(t, startupProbe)
+			envVars, envVarErr := s.GetEnvironmentVariables(logr.Discard(), tt.args.config)
+			assert.NoError(t, envVarErr)
+			assert.Nil(t, envVars)
 		})
 	}
 }

--- a/internal/components/receivers/k8sevents_test.go
+++ b/internal/components/receivers/k8sevents_test.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receivers
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratek8seventsRbacRules(t *testing.T) {
+	rules, err := generatek8seventsRbacRules(logr.Logger{}, k8seventsConfig{})
+	require.NoError(t, err)
+	require.Len(t, rules, 5)
+
+	assert.Equal(t, []string{""}, rules[0].APIGroups)
+	assert.Contains(t, rules[0].Resources, "events")
+	assert.Contains(t, rules[0].Resources, "namespaces")
+	assert.Contains(t, rules[0].Resources, "pods")
+	assert.Contains(t, rules[0].Resources, "nodes")
+	assert.Contains(t, rules[0].Resources, "services")
+	assert.Equal(t, []string{"get", "list", "watch"}, rules[0].Verbs)
+
+	assert.Equal(t, []string{"apps"}, rules[1].APIGroups)
+	assert.Contains(t, rules[1].Resources, "daemonsets")
+	assert.Contains(t, rules[1].Resources, "deployments")
+	assert.Contains(t, rules[1].Resources, "replicasets")
+	assert.Contains(t, rules[1].Resources, "statefulsets")
+
+	assert.Equal(t, []string{"extensions"}, rules[2].APIGroups)
+	assert.Contains(t, rules[2].Resources, "daemonsets")
+	assert.Contains(t, rules[2].Resources, "deployments")
+	assert.Contains(t, rules[2].Resources, "replicasets")
+
+	assert.Equal(t, []string{"batch"}, rules[3].APIGroups)
+	assert.Contains(t, rules[3].Resources, "jobs")
+	assert.Contains(t, rules[3].Resources, "cronjobs")
+
+	assert.Equal(t, []string{"autoscaling"}, rules[4].APIGroups)
+	assert.Contains(t, rules[4].Resources, "horizontalpodautoscalers")
+}

--- a/internal/components/receivers/kubeletstats_test.go
+++ b/internal/components/receivers/kubeletstats_test.go
@@ -12,6 +12,36 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
+func TestGenerateKubeletStatsEnvVars(t *testing.T) {
+	tests := []struct {
+		name   string
+		config kubeletStatsConfig
+	}{
+		{
+			name:   "default config",
+			config: kubeletStatsConfig{},
+		},
+		{
+			name: "with serviceAccount auth type",
+			config: kubeletStatsConfig{
+				AuthType: "serviceAccount",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envVars, err := generateKubeletStatsEnvVars(logr.Logger{}, tt.config)
+			require.NoError(t, err)
+			require.Len(t, envVars, 1)
+			assert.Equal(t, "K8S_NODE_NAME", envVars[0].Name)
+			require.NotNil(t, envVars[0].ValueFrom)
+			require.NotNil(t, envVars[0].ValueFrom.FieldRef)
+			assert.Equal(t, "spec.nodeName", envVars[0].ValueFrom.FieldRef.FieldPath)
+		})
+	}
+}
+
 func TestGenerateKubeletStatsRbacRules(t *testing.T) {
 	baseRule := rbacv1.PolicyRule{
 		APIGroups: []string{""},

--- a/internal/components/tls_profile_test.go
+++ b/internal/components/tls_profile_test.go
@@ -4,10 +4,12 @@
 package components
 
 import (
+	"context"
 	"crypto/tls"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStaticProfile(t *testing.T) {
@@ -19,10 +21,94 @@ func TestStaticProfile(t *testing.T) {
 }
 
 func TestStaticProfileTLS13ReturnsNilCiphers(t *testing.T) {
-	// TLS 1.3 cipher suites are not configurable in Go, so CipherSuites() and CipherSuiteNames() should return nil
 	profile := NewStaticTLSProfile(tls.VersionTLS13, []uint16{tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384})
 	assert.Equal(t, uint16(tls.VersionTLS13), profile.MinTLSVersion())
 	assert.Nil(t, profile.CipherSuites(), "TLS 1.3 should return nil for CipherSuites")
 	assert.Nil(t, profile.CipherSuiteNames(), "TLS 1.3 should return nil for CipherSuiteNames")
 	assert.Equal(t, "1.3", profile.MinTLSVersionOTEL())
+}
+
+func TestStaticTLSProfileProvider_GetTLSProfile(t *testing.T) {
+	profile := NewStaticTLSProfile(tls.VersionTLS12, []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256})
+	provider := StaticTLSProfileProvider{Profile: profile}
+
+	got, err := provider.GetTLSProfile(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "1.2", got.MinTLSVersionOTEL())
+	assert.Equal(t, uint16(tls.VersionTLS12), got.MinTLSVersion())
+}
+
+func TestStaticTLSProfileProvider_GetTLSProfile_NilProfile(t *testing.T) {
+	provider := StaticTLSProfileProvider{Profile: nil}
+
+	got, err := provider.GetTLSProfile(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestMinTLSVersionGolang(t *testing.T) {
+	tests := []struct {
+		name       string
+		minVersion uint16
+		want       string
+	}{
+		{"TLS 1.0", tls.VersionTLS10, "TLS 1.0"},
+		{"TLS 1.1", tls.VersionTLS11, "TLS 1.1"},
+		{"TLS 1.2", tls.VersionTLS12, "TLS 1.2"},
+		{"TLS 1.3", tls.VersionTLS13, "TLS 1.3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := NewStaticTLSProfile(tt.minVersion, nil)
+			assert.Equal(t, tt.want, profile.MinTLSVersionGolang())
+		})
+	}
+}
+
+func TestTLSVersionToCollectorFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		version uint16
+		want    string
+	}{
+		{"TLS 1.0", tls.VersionTLS10, "1.0"},
+		{"TLS 1.1", tls.VersionTLS11, "1.1"},
+		{"TLS 1.2", tls.VersionTLS12, "1.2"},
+		{"TLS 1.3", tls.VersionTLS13, "1.3"},
+		{"unknown defaults to 1.2", 0, "1.2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, TLSVersionToCollectorFormat(tt.version))
+		})
+	}
+}
+
+func TestApplyTLSProfileDefaults(t *testing.T) {
+	profile := NewStaticTLSProfile(tls.VersionTLS12, []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256})
+
+	t.Run("applies defaults to empty config", func(t *testing.T) {
+		cfg := &TLSConfig{}
+		cfg.ApplyTLSProfileDefaults(profile)
+		assert.Equal(t, "1.2", cfg.MinVersion)
+		assert.Equal(t, []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}, cfg.Ciphers)
+	})
+
+	t.Run("does not override existing values", func(t *testing.T) {
+		cfg := &TLSConfig{MinVersion: "1.3", Ciphers: []string{"existing"}}
+		cfg.ApplyTLSProfileDefaults(profile)
+		assert.Equal(t, "1.3", cfg.MinVersion)
+		assert.Equal(t, []string{"existing"}, cfg.Ciphers)
+	})
+
+	t.Run("nil config is safe", func(t *testing.T) {
+		var cfg *TLSConfig
+		assert.NotPanics(t, func() { cfg.ApplyTLSProfileDefaults(profile) })
+	})
+
+	t.Run("nil profile is safe", func(t *testing.T) {
+		cfg := &TLSConfig{}
+		assert.NotPanics(t, func() { cfg.ApplyTLSProfileDefaults(nil) })
+		assert.Empty(t, cfg.MinVersion)
+	})
 }

--- a/internal/manifests/collector/container_test.go
+++ b/internal/manifests/collector/container_test.go
@@ -4,6 +4,7 @@
 package collector
 
 import (
+	"os"
 	"testing"
 
 	go_yaml "github.com/goccy/go-yaml"
@@ -20,6 +21,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
+
+func clearProxyEnvVars(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
+		t.Setenv(v, "")
+		os.Unsetenv(v)
+	}
+}
 
 var metricContainerPort = corev1.ContainerPort{
 	Name:          "metrics",
@@ -492,6 +501,7 @@ func TestContainerCustomSecurityContext(t *testing.T) {
 }
 
 func TestContainerEnvVarsOverridden(t *testing.T) {
+	clearProxyEnvVars(t)
 	otelcol := v1beta1.OpenTelemetryCollector{
 		Spec: v1beta1.OpenTelemetryCollectorSpec{
 			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
@@ -520,6 +530,7 @@ func TestContainerEnvVarsOverridden(t *testing.T) {
 }
 
 func TestContainerDefaultEnvVars(t *testing.T) {
+	clearProxyEnvVars(t)
 	otelcol := v1beta1.OpenTelemetryCollector{
 		Spec: v1beta1.OpenTelemetryCollectorSpec{},
 	}
@@ -1244,6 +1255,7 @@ service:
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			clearProxyEnvVars(t)
 			registry := colfg.GlobalRegistry()
 			if test.enableSetGolangFlags {
 				originalVal := featuregate.SetGolangFlags.IsEnabled()


### PR DESCRIPTION
**Description:** Fix environment-dependent test unpredictability in collector container tests and add unit tests for nine previously untested component functions.

1. Three tests (`TestContainerEnvVarsOverridden`, `TestContainerDefaultEnvVars`, `TestGetEnvironmentVariables/default`) fail on machines where proxy environment variables (`NO_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`) are set, because `proxy.ReadProxyVarsFromEnv()` injects them into the container env list and the tests assert exact counts. Added a `clearProxyEnvVars` helper that unsets proxy vars for the duration of each affected test.
2. Added test coverage for functions previously at 0%: `generatek8seventsRbacRules`, `generateKubeletStatsEnvVars`, `GenericParser.GetEnvironmentVariables`, `MultiPortReceiver.GetEnvironmentVariables`, `Builder.WithEnvVarGen`, `StaticTLSProfileProvider.GetTLSProfile`, `StaticTLSProfile.MinTLSVersionGolang`, `TLSVersionToCollectorFormat`, and `TLSConfig.ApplyTLSProfileDefaults`. All now at 100%. Component package coverage improved from 92.9% to 98.3%.

**Link to tracking Issue(s):** None

**Testing:** Ran `go test -race ./internal/components/... ./internal/manifests/collector/...` — all tests pass. Verified the three previously failing tests now pass with proxy env vars set. Confirmed coverage improvement via `go tool cover -func`.

**Documentation:** No documentation changes needed.
